### PR TITLE
Fix remapping not found in `config/aave-v2/Config.sol` file

### DIFF
--- a/config/aave-v2/Config.sol
+++ b/config/aave-v2/Config.sol
@@ -7,7 +7,7 @@ import {ILendingPoolAddressesProvider} from "src/aave-v2/interfaces/aave/ILendin
 import {IEntryPositionsManager} from "src/aave-v2/interfaces/IEntryPositionsManager.sol";
 import {IExitPositionsManager} from "src/aave-v2/interfaces/IExitPositionsManager.sol";
 import {IInterestRatesManager} from "src/aave-v2/interfaces/IInterestRatesManager.sol";
-import {ILendingPoolConfigurator} from "../../../test/aave-v2/helpers/ILendingPoolConfigurator.sol";
+import {ILendingPoolConfigurator} from "../../test/aave-v2/helpers/ILendingPoolConfigurator.sol";
 import {IMorpho} from "src/aave-v2/interfaces/IMorpho.sol";
 
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";

--- a/config/aave-v2/Config.sol
+++ b/config/aave-v2/Config.sol
@@ -7,7 +7,7 @@ import {ILendingPoolAddressesProvider} from "src/aave-v2/interfaces/aave/ILendin
 import {IEntryPositionsManager} from "src/aave-v2/interfaces/IEntryPositionsManager.sol";
 import {IExitPositionsManager} from "src/aave-v2/interfaces/IExitPositionsManager.sol";
 import {IInterestRatesManager} from "src/aave-v2/interfaces/IInterestRatesManager.sol";
-import {ILendingPoolConfigurator} from "../../test/aave-v2/helpers/ILendingPoolConfigurator.sol";
+import {ILendingPoolConfigurator} from "test/aave-v2/helpers/ILendingPoolConfigurator.sol";
 import {IMorpho} from "src/aave-v2/interfaces/IMorpho.sol";
 
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";


### PR DESCRIPTION
Reproduce warning when doing `PROTOCOL=aave-v2 make test` for example, or from the linter by navigating to this file